### PR TITLE
feat(engines): MOSS-TTS-Nano installs into its own venv, pinned to a working upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ the frozen-backend fallback mirror it for their toolchains.
 **Highlights**
 - MOSS-TTS-v1.5, Confucius4-TTS, dots.tts, Supertonic-3 and PocketTTS install in one click, each in its own environment, so switching engines and back never breaks a working one (#2015, #2016)
 - VoxCPM2 installs in one click into its own environment, with the CUDA build of PyTorch on NVIDIA GPUs (#2021)
+- MOSS-TTS-Nano installs in one click into its own environment, pinned to a reviewed upstream commit it works with (#NANOPR)
 - A pronunciation entry that is stored but not applied yet says so, instead of looking like it did not match (#1949)
 - A bare 500 report now names the backend error class, so two unrelated faults stop filing the same issue (#1773)
 - A rejected dubbing source language now names the code it rejected (#1960)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ the frozen-backend fallback mirror it for their toolchains.
 **Highlights**
 - MOSS-TTS-v1.5, Confucius4-TTS, dots.tts, Supertonic-3 and PocketTTS install in one click, each in its own environment, so switching engines and back never breaks a working one (#2015, #2016)
 - VoxCPM2 installs in one click into its own environment, with the CUDA build of PyTorch on NVIDIA GPUs (#2021)
-- MOSS-TTS-Nano installs in one click into its own environment, pinned to a reviewed upstream commit it works with (#NANOPR)
+- MOSS-TTS-Nano installs in one click into its own environment, pinned to a reviewed upstream commit it works with (#2022)
 - A pronunciation entry that is stored but not applied yet says so, instead of looking like it did not match (#1949)
 - A bare 500 report now names the backend error class, so two unrelated faults stop filing the same issue (#1773)
 - A rejected dubbing source language now names the code it rejected (#1960)

--- a/backend/engines/moss_tts_nano_subprocess/__init__.py
+++ b/backend/engines/moss_tts_nano_subprocess/__init__.py
@@ -1,0 +1,89 @@
+"""moss-tts-nano-subprocess: MOSS-TTS-Nano from its own venv (one-click install).
+
+The in-process engine needs ``moss_tts_nano`` installed into VoiceStudio's own
+environment, with upstream's exact pins (torch 2.7.0, transformers 4.57.1)
+landing there too. It also looks for a model class the package no longer
+exports: at the commit pinned here, ``moss_tts_nano`` exports only
+``__version__``, and the entry point is the top-level
+``moss_tts_nano_runtime.NanoTTSService``. The one-click installer clones that
+reviewed commit into ``DATA_DIR/engines/moss-tts-nano/`` with its own venv,
+and this class runs upstream's runtime there in a sidecar.
+
+The engine id stays ``moss-tts-nano``. ``tts_backend._effective_backend_class``
+resolves to this class once that venv exists, and to the in-process
+``MossTTSNanoBackend`` otherwise.
+"""
+from __future__ import annotations
+
+import math
+import os
+from pathlib import Path
+
+from services.subprocess_backend import SubprocessBackend
+
+VENV_ENV_VAR = "OMNIVOICE_MOSS_TTS_NANO_DIR"
+
+
+def own_venv_python() -> "Path | None":
+    """The venv the one-click installer made for MOSS-TTS-Nano, if any."""
+    from services.sidecar_install import engine_venv_python
+
+    return engine_venv_python(VENV_ENV_VAR)
+
+
+class MossTTSNanoSubprocessBackend(SubprocessBackend):
+    """MOSS-TTS-Nano in a killable sidecar running the engine's own venv."""
+
+    id = "moss-tts-nano"
+    display_name = "MOSS-TTS-Nano (20 langs, CPU realtime, 48 kHz)"
+    gpu_compat = ("cuda", "cpu")
+    _DEFAULT_SAMPLE_RATE = 48_000
+
+    @classmethod
+    def is_available(cls) -> tuple[bool, str]:
+        if own_venv_python() is None:
+            return False, (
+                "moss_tts_nano package not installed. Install it from "
+                "Model Catalogue → Engines."
+            )
+        return True, "ready"
+
+    @classmethod
+    def venv_python(cls) -> Path:
+        py = own_venv_python()
+        if py is None:
+            raise RuntimeError(
+                "MOSS-TTS-Nano's environment is missing. Reinstall it from "
+                "Model Catalogue → Engines."
+            )
+        return py
+
+    @classmethod
+    def sidecar_script(cls) -> Path:
+        return Path(__file__).resolve().parent / "main.py"
+
+    @property
+    def recv_timeout_s(self) -> float:
+        # A cold load downloads the model and its audio tokenizer; the sidecar
+        # heartbeats progress frames meanwhile, and each re-arms this deadline.
+        try:
+            v = float(os.environ.get("OMNIVOICE_MOSS_TTS_NANO_RECV_TIMEOUT_S", "900"))
+        except (TypeError, ValueError):
+            return 900.0
+        if not math.isfinite(v):  # reject inf/nan so the deadline can't be disabled
+            return 900.0
+        return max(30.0, v)
+
+    @property
+    def sample_rate(self) -> int:
+        # The sidecar resamples to this rate if upstream ever returns another.
+        return self._DEFAULT_SAMPLE_RATE
+
+    @property
+    def supported_languages(self) -> list[str]:
+        from services.tts_backend import MossTTSNanoBackend
+
+        return MossTTSNanoBackend.supported_languages.fget(self)
+
+
+__all__ = ["MossTTSNanoSubprocessBackend", "VENV_ENV_VAR", "own_venv_python"]

--- a/backend/engines/moss_tts_nano_subprocess/main.py
+++ b/backend/engines/moss_tts_nano_subprocess/main.py
@@ -1,0 +1,254 @@
+"""moss-tts-nano sidecar: MOSS-TTS-Nano in the engine's own venv (one-click install).
+
+Launched as ``<engine venv python> main.py`` by MossTTSNanoSubprocessBackend.
+The venv holds the reviewed upstream checkout, installed editable, and its
+pinned dependencies, so this file imports nothing from the app. It drives the
+runtime that checkout ships, ``moss_tts_nano_runtime.NanoTTSService``.
+
+Wire protocol: identical to the other sidecars (engines/pockettts/main.py).
+Progress frames are sent while the model loads and through the first
+synthesis, which is when upstream fetches its audio tokenizer. Later calls
+send none, so the parent's watchdog still catches a generation that wedges.
+"""
+from __future__ import annotations
+
+import base64
+import contextlib
+import json
+import os
+import re
+import struct
+import sys
+import tempfile
+import threading
+import time
+import traceback
+
+# Mirrors services/subprocess_backend.py::MAX_FRAME_BYTES.
+MAX_FRAME_BYTES = 64 * 1024 * 1024
+#: The rate the engine reports; upstream's output is resampled to it if needed.
+NANO_SAMPLE_RATE = 48_000
+_HEARTBEAT_S = 5.0
+#: ref_audio must be a local file path, not a URL (local-first; no SSRF).
+_URL_RE = re.compile(r"^[a-z][a-z0-9+.\-]*://", re.IGNORECASE)
+#: A download failure worth retrying; anything else propagates at once.
+_TRANSIENT_MARKERS = (
+    "connection", "timed out", "timeout", "peer closed", "incomplete",
+    "remoteprotocolerror", "temporarily unavailable",
+)
+
+_SERVICE = None
+_WARM = False
+
+# -- wire protocol -----------------------------------------------------------
+
+_send_lock = threading.Lock()
+
+
+def _send(stream, obj: dict) -> None:
+    body = json.dumps(obj, separators=(",", ":")).encode("utf-8")
+    with _send_lock:
+        stream.write(struct.pack("!I", len(body)))
+        stream.write(body)
+        stream.flush()
+
+
+def _recv(stream):
+    header = stream.read(4)
+    if len(header) < 4:
+        return None  # EOF
+    (n,) = struct.unpack("!I", header)
+    if n > MAX_FRAME_BYTES:
+        raise IOError(f"frame too large: {n}")
+    body = bytearray()
+    while len(body) < n:
+        chunk = stream.read(n - len(body))
+        if not chunk:
+            raise IOError("short read")
+        body.extend(chunk)
+    return json.loads(bytes(body).decode("utf-8"))
+
+
+def _measure_vram_mb() -> float:
+    try:
+        import torch  # noqa: PLC0415
+
+        if torch.cuda.is_available():
+            return float(torch.cuda.memory_allocated()) / (1024 * 1024)
+    except Exception:  # noqa: BLE001 — a probe, never fatal
+        pass
+    return 0.0
+
+
+# -- loading -----------------------------------------------------------------
+
+
+def _with_retries(action):
+    """Run ``action``, retrying a transient download failure with a short
+    backoff, the way the app's own loader does for in-process engines."""
+    try:
+        attempts = max(1, int(os.environ.get("OMNIVOICE_MODEL_LOAD_RETRIES", "3")))
+    except ValueError:
+        attempts = 3
+    for attempt in range(1, attempts + 1):
+        try:
+            return action()
+        except Exception as exc:  # noqa: BLE001 — classified below
+            text = f"{type(exc).__name__}: {exc}".lower()
+            if attempt == attempts or not any(m in text for m in _TRANSIENT_MARKERS):
+                raise
+            time.sleep(2.0 * attempt)
+    raise AssertionError("unreachable")
+
+
+@contextlib.contextmanager
+def _heartbeat(stdout, stage: str):
+    """Progress frames every few seconds while a download may be running."""
+    stop = threading.Event()
+
+    def beat() -> None:
+        pct = 1
+        while not stop.wait(_HEARTBEAT_S):
+            pct = min(pct + 1, 99)
+            _send(stdout, {"op": "progress", "stage": stage, "percent": pct})
+
+    thread = threading.Thread(target=beat, daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        thread.join(timeout=_HEARTBEAT_S + 1)
+
+
+def _load_service(stdout):
+    global _SERVICE
+    if _SERVICE is not None:
+        return _SERVICE
+    _send(stdout, {"op": "progress", "stage": "loading_model", "percent": 0})
+    with _heartbeat(stdout, "loading_model"):
+        from moss_tts_nano.defaults import (  # type: ignore[import-not-found]  # noqa: PLC0415
+            DEFAULT_AUDIO_TOKENIZER_PATH,
+            DEFAULT_CHECKPOINT_PATH,
+        )
+        from moss_tts_nano_runtime import NanoTTSService  # type: ignore[import-not-found]  # noqa: PLC0415
+
+        service = NanoTTSService(
+            checkpoint_path=os.environ.get("OMNIVOICE_MOSS_TTS_MODEL", DEFAULT_CHECKPOINT_PATH),
+            audio_tokenizer_path=os.environ.get(
+                "OMNIVOICE_MOSS_TTS_TOKENIZER", DEFAULT_AUDIO_TOKENIZER_PATH
+            ),
+            # Upstream writes every synthesis to a file; keep them out of the
+            # install folder (and see _handle_synthesize: one file, reused).
+            output_dir=tempfile.mkdtemp(prefix="moss-tts-nano-"),
+        )
+        _with_retries(lambda: service.preload(load_model=True))
+        _SERVICE = service
+    _send(stdout, {"op": "progress", "stage": "loading_model", "percent": 100})
+    return _SERVICE
+
+
+# -- synthesis ---------------------------------------------------------------
+
+
+def _mono_pcm_b64(result: dict) -> tuple[str, int]:
+    """Upstream's waveform, downmixed to mono at NANO_SAMPLE_RATE, as base64
+    int16 PCM. The in-process engine downmixed the same way."""
+    import numpy as np  # noqa: PLC0415
+
+    wav = np.asarray(result["waveform_numpy"], dtype=np.float32)
+    if wav.ndim == 2:  # (samples, channels): the layout upstream returns
+        wav = wav.mean(axis=1)
+    sr = int(result.get("sample_rate") or NANO_SAMPLE_RATE)
+    if sr != NANO_SAMPLE_RATE:
+        import torch  # noqa: PLC0415
+        import torchaudio  # noqa: PLC0415
+
+        wav = torchaudio.functional.resample(torch.from_numpy(wav), sr, NANO_SAMPLE_RATE).numpy()
+    wav = np.clip(wav, -1.0, 1.0)
+    pcm = (wav * 32767.0).astype(np.int16).tobytes()
+    return base64.b64encode(pcm).decode("ascii"), int(wav.shape[-1])
+
+
+def _handle_synthesize(msg: dict, stdout) -> None:
+    global _WARM
+    text = msg.get("text")
+    if not text or not isinstance(text, str):
+        raise ValueError("synthesize: missing or non-string 'text'")
+    ref_audio = msg.get("ref_audio") or None
+    if ref_audio and _URL_RE.match(str(ref_audio)):
+        raise ValueError(
+            "ref_audio must be a local file path; URLs are not accepted (local-first)."
+        )
+    service = _load_service(stdout)
+    kwargs = {
+        "text": text,
+        # Reference cloning, as the in-process engine did; with no clip,
+        # upstream uses its default voice preset.
+        "mode": "voice_clone",
+        "prompt_audio_path": ref_audio,
+        "output_audio_path": os.path.join(str(service.output_dir), "last.wav"),
+    }
+    if _WARM:
+        result = service.synthesize(**kwargs)
+    else:
+        with _heartbeat(stdout, "loading_model"):
+            result = _with_retries(lambda: service.synthesize(**kwargs))
+        _WARM = True
+    pcm_b64, n_samples = _mono_pcm_b64(result)
+    _send(stdout, {
+        "op": "audio",
+        "audio_pcm_b64": pcm_b64,
+        "sample_rate": NANO_SAMPLE_RATE,
+        "n_samples": n_samples,
+    })
+
+
+# -- main loop ---------------------------------------------------------------
+
+
+def main() -> int:
+    stdin = sys.stdin.buffer
+    # Frames go down a PRIVATE fd, and fd 1 is pointed at stderr (#1428): the
+    # libraries this loads print to fd 1, and those bytes would otherwise
+    # interleave with the length-prefixed frames.
+    _frame_fd = os.dup(1)
+    os.dup2(2, 1)
+    stdout = os.fdopen(_frame_fd, "wb")
+
+    _send(stdout, {"op": "ready", "engine": "moss-tts-nano", "sample_rate": NANO_SAMPLE_RATE})
+
+    while True:
+        try:
+            msg = _recv(stdin)
+        except Exception as exc:  # noqa: BLE001
+            _send(stdout, {
+                "op": "error",
+                "stage": "recv",
+                "message": f"{type(exc).__name__}: {exc}",
+                "traceback": traceback.format_exc(),
+            })
+            return 1
+        if msg is None:
+            return 0
+        op = msg.get("op") if isinstance(msg, dict) else None
+        try:
+            if op == "ping":
+                _send(stdout, {"op": "pong", "vram_mb": _measure_vram_mb()})
+            elif op == "synthesize":
+                _handle_synthesize(msg, stdout)
+            elif op == "shutdown":
+                return 0
+            else:
+                _send(stdout, {"op": "error", "stage": "dispatch", "message": f"unknown op: {op!r}"})
+        except Exception as exc:  # noqa: BLE001
+            _send(stdout, {
+                "op": "error",
+                "stage": op or "unknown",
+                "message": f"{type(exc).__name__}: {exc}",
+                "traceback": traceback.format_exc(),
+            })
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/services/sidecar_install.py
+++ b/backend/services/sidecar_install.py
@@ -239,22 +239,15 @@ def _dots_host() -> tuple[bool, str]:
     )
 
 
-def _pockettts_host() -> tuple[bool, str]:
-    import platform
-    if sys.platform == "darwin" and platform.machine().lower() == "x86_64":
-        return False, (
-            "PocketTTS needs a PyTorch version that has no Intel Mac build."
-        )
-    return True, ""
-
-
-def _voxcpm2_host() -> tuple[bool, str]:
-    import platform
-    if sys.platform == "darwin" and platform.machine().lower() == "x86_64":
-        return False, (
-            "VoxCPM2 needs a PyTorch version that has no Intel Mac build."
-        )
-    return True, ""
+def _no_intel_mac(message: str) -> Callable[[], tuple[bool, str]]:
+    """A host gate for an engine whose pinned PyTorch has no Intel Mac build
+    (PyTorch stopped publishing macOS x86_64 wheels after 2.2)."""
+    def gate() -> tuple[bool, str]:
+        import platform
+        if sys.platform == "darwin" and platform.machine().lower() == "x86_64":
+            return False, message
+        return True, ""
+    return gate
 
 
 def _in_app_env(module: str) -> Callable[[], bool]:
@@ -427,7 +420,9 @@ SPECS: dict[str, SidecarSpec] = {
         # CPU torch + scipy. The gated weights download on first use.
         required_bytes=3 * _GIB,
         installed_probe=_in_app_env("pocket_tts"),
-        host_supported=_pockettts_host,
+        host_supported=_no_intel_mac(
+            "PocketTTS needs a PyTorch version that has no Intel Mac build."
+        ),
     ),
     # Run in a sidecar from its own venv (engines/voxcpm2_subprocess). voxcpm
     # leaves torch unpinned, so the pair is pinned here; each build of it was
@@ -449,7 +444,37 @@ SPECS: dict[str, SidecarSpec] = {
         # CUDA torch (~5 GB unpacked) + transformers.
         required_bytes=10 * _GIB,
         installed_probe=_in_app_env("voxcpm"),
-        host_supported=_voxcpm2_host,
+        host_supported=_no_intel_mac(
+            "VoxCPM2 needs a PyTorch version that has no Intel Mac build."
+        ),
+    ),
+    # Upstream is unpinned and its entry point has moved before (#1287), so the
+    # install pins a reviewed commit (2026-09-06) and the sidecar drives the
+    # runtime that commit ships (moss_tts_nano_runtime.NanoTTSService). Its
+    # pyproject pins torch==2.7.0 exactly, so the CUDA index yields +cu128.
+    "moss-tts-nano": SidecarSpec(
+        engine_id="moss-tts-nano",
+        display_name="MOSS-TTS-Nano",
+        repo_url="https://github.com/OpenMOSS/MOSS-TTS-Nano.git",
+        tarball_url=(
+            "https://github.com/OpenMOSS/MOSS-TTS-Nano/archive/"
+            "8b7bcc9341b3b4ef3a3a58ba1338a7d85ff133eb.tar.gz"
+        ),
+        checkout_dirname="MOSS-TTS-Nano",
+        env_var="OMNIVOICE_MOSS_TTS_NANO_DIR",
+        probe_module="moss_tts_nano_runtime",
+        source_revision="8b7bcc9341b3b4ef3a3a58ba1338a7d85ff133eb",
+        source_required_path="moss_tts_nano_runtime.py",
+        docs_path="docs/engines/moss-tts-nano.md",
+        venv_args=("--python", "3.11"),
+        uses_cuda_index=True,
+        # torch 2.7 (CUDA build on NVIDIA hosts) + transformers + onnxruntime.
+        # The model and its audio tokenizer download on first synthesis.
+        required_bytes=8 * _GIB,
+        installed_probe=_in_app_env("moss_tts_nano"),
+        host_supported=_no_intel_mac(
+            "MOSS-TTS-Nano pins a PyTorch version that has no Intel Mac build."
+        ),
     ),
 }
 

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -2657,18 +2657,28 @@ def list_backends(*, include_hidden: bool = False) -> list[dict]:
     return out
 
 
+# In-process engines that also run from a venv of their own once the
+# one-click installer has made one: engine id -> (sidecar module, class). Each
+# module exposes own_venv_python(); an install made into the app's environment
+# keeps running in-process.
+_OWN_VENV_SIDECARS: dict[str, tuple[str, str]] = {
+    "voxcpm2": ("engines.voxcpm2_subprocess", "VoxCPM2SubprocessBackend"),
+    "moss-tts-nano": ("engines.moss_tts_nano_subprocess", "MossTTSNanoSubprocessBackend"),
+}
+
+
 def _effective_backend_class(
     backend_id: str,
     backend_cls: type[TTSBackend],
     host_family: str | None = None,
 ) -> type[TTSBackend]:
     """Resolve host-specific containment without changing the configured id."""
-    if backend_id == "voxcpm2":
-        # Its own venv (one-click install) runs in a sidecar; an install made
-        # with `pip install voxcpm` keeps running in-process.
-        from engines.voxcpm2_subprocess import VoxCPM2SubprocessBackend, own_venv_python
+    sidecar = _OWN_VENV_SIDECARS.get(backend_id)
+    if sidecar is not None:
+        import importlib
 
-        return VoxCPM2SubprocessBackend if own_venv_python() is not None else backend_cls
+        module = importlib.import_module(sidecar[0])
+        return getattr(module, sidecar[1]) if module.own_venv_python() is not None else backend_cls
     if backend_id != "omnivoice":
         return backend_cls
     if host_family is None:

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -44,7 +44,7 @@ VoiceStudio/
 │   ├── engines/                 per-engine adapters: indextts, supertonic3, confucius4,
 │   │                            dots_tts, moss_tts_v15, pockettts, audiocpp,
 │   │                            omnivoice_gguf, omnivoice_subprocess, _asr_sidecar, _echo,
-│   │                            voxcpm2_subprocess
+│   │                            voxcpm2_subprocess, moss_tts_nano_subprocess
 │   ├── worker/                  remote / distributed workers — scheduler, pool, routing,
 │   │                            breaker, capacity, plus protocol/ and inbound/
 │   ├── mcp_shim/                MCP server entry point (docs/mcp.md)

--- a/docs/engines/moss-tts-nano.md
+++ b/docs/engines/moss-tts-nano.md
@@ -58,12 +58,31 @@ shows unavailable with a "does not expose a usable model class" message,
 pull the latest upstream and re-run `uv pip install -e .`, or open an issue
 with the version you have.
 
+The one-click install is not affected: it pins a reviewed commit
+(`8b7bcc93`, 2026-09-06) and drives the runtime that commit ships.
+
 ## Known limits
 
 - No voice design, no instruct, no speed control — cloning from a reference
   clip only.
 - Quality sits below the large engines; see
   [benchmarks.md](../benchmarks.md).
+
+## One-click install
+
+Click **Install** in **Model Catalogue → Engines → MOSS-TTS-Nano**.
+VoiceStudio clones a reviewed upstream commit into its own folder under the
+data directory, gives it its own Python environment (the CUDA build of
+PyTorch on an NVIDIA GPU), and runs it there in a separate process.
+
+Nothing it installs touches VoiceStudio itself or any other engine, and
+**Uninstall** in the same row removes only that folder. The button is not
+offered on Intel Macs, where the PyTorch version it pins has no build.
+
+The first synthesis downloads the model and its audio tokenizer. The
+generation stays alive while the download makes progress; if a stalled
+download runs out of time, raise the compute-time budget in
+**Settings → Performance & Device** and try again.
 
 ## Troubleshooting
 

--- a/tests/test_moss_tts_nano_subprocess.py
+++ b/tests/test_moss_tts_nano_subprocess.py
@@ -120,7 +120,7 @@ def test_the_sidecar_imports_nothing_from_the_app():
 def test_the_class_switches_to_the_sidecar_once_its_venv_exists(monkeypatch, tmp_path):
     from engines.moss_tts_nano_subprocess import MossTTSNanoSubprocessBackend
     from services import tts_backend
-    from services.sidecar_install import _venv_python
+    from services.sidecar_install import _INSTALL_COMPLETE_MARKER, _venv_python
 
     monkeypatch.setenv("OMNIVOICE_MOSS_TTS_NANO_DIR", "")
     monkeypatch.delenv("OMNIVOICE_MOSS_TTS_NANO_DIR")
@@ -129,6 +129,7 @@ def test_the_class_switches_to_the_sidecar_once_its_venv_exists(monkeypatch, tmp
     py = _venv_python(tmp_path / ".venv")
     py.parent.mkdir(parents=True)
     py.write_text("#!fake\n")
+    (tmp_path / _INSTALL_COMPLETE_MARKER).write_text("x\n", encoding="utf-8")
     monkeypatch.setenv("OMNIVOICE_MOSS_TTS_NANO_DIR", str(tmp_path))
 
     cls = tts_backend.get_backend_class("moss-tts-nano")

--- a/tests/test_moss_tts_nano_subprocess.py
+++ b/tests/test_moss_tts_nano_subprocess.py
@@ -1,0 +1,155 @@
+"""MOSS-TTS-Nano from its own venv: the sidecar, and the switch to it.
+
+At the pinned upstream commit, `moss_tts_nano` exports only `__version__` and
+the entry point is the top-level `moss_tts_nano_runtime.NanoTTSService`. These
+tests run the sidecar against a fake of that runtime.
+"""
+import importlib.util
+import io
+import json
+import re
+import struct
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_MAIN = Path(__file__).resolve().parents[1] / "backend/engines/moss_tts_nano_subprocess/main.py"
+
+
+def _load_sidecar(monkeypatch, calls, *, sample_rate=48000, channels=2, samples=960):
+    class NanoTTSService:
+        def __init__(self, **kw):
+            calls.append(("init", kw))
+            self.output_dir = Path(kw["output_dir"])
+
+        def preload(self, **kw):
+            calls.append(("preload", kw))
+
+        def synthesize(self, **kw):
+            calls.append(("synthesize", kw))
+            shape = (samples, channels) if channels > 1 else (samples,)
+            return {"waveform_numpy": np.full(shape, 0.25, dtype=np.float32), "sample_rate": sample_rate}
+
+    runtime = types.ModuleType("moss_tts_nano_runtime")
+    runtime.NanoTTSService = NanoTTSService
+    package = types.ModuleType("moss_tts_nano")
+    defaults = types.ModuleType("moss_tts_nano.defaults")
+    defaults.DEFAULT_CHECKPOINT_PATH = "OpenMOSS-Team/MOSS-TTS-Nano"
+    defaults.DEFAULT_AUDIO_TOKENIZER_PATH = "OpenMOSS-Team/MOSS-Audio-Tokenizer-Nano"
+    package.defaults = defaults
+    monkeypatch.setitem(sys.modules, "moss_tts_nano_runtime", runtime)
+    monkeypatch.setitem(sys.modules, "moss_tts_nano", package)
+    monkeypatch.setitem(sys.modules, "moss_tts_nano.defaults", defaults)
+    spec = importlib.util.spec_from_file_location("_nano_sidecar_under_test", _MAIN)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _frames(buf):
+    data, out, i = buf.getvalue(), [], 0
+    while i < len(data):
+        (n,) = struct.unpack("!I", data[i:i + 4])
+        out.append(json.loads(data[i + 4:i + 4 + n]))
+        i += 4 + n
+    return out
+
+
+def test_drives_upstreams_runtime_and_downmixes_to_mono(monkeypatch):
+    calls = []
+    sidecar = _load_sidecar(monkeypatch, calls)
+    out = io.BytesIO()
+
+    sidecar._handle_synthesize({"op": "synthesize", "text": "hello"}, out)
+
+    init = dict(calls)["init"]
+    assert init["checkpoint_path"] == "OpenMOSS-Team/MOSS-TTS-Nano"
+    assert init["audio_tokenizer_path"] == "OpenMOSS-Team/MOSS-Audio-Tokenizer-Nano"
+    assert ("preload", {"load_model": True}) in calls
+    synth = dict(calls)["synthesize"]
+    assert synth["text"] == "hello"
+    assert synth["mode"] == "voice_clone"
+    assert synth["prompt_audio_path"] is None
+    # One output file, reused, inside the temp dir — not one per call.
+    assert Path(synth["output_audio_path"]).parent == Path(init["output_dir"])
+    audio = _frames(out)[-1]
+    assert audio["op"] == "audio"
+    assert audio["sample_rate"] == 48000 and audio["n_samples"] == 960
+
+
+def test_passes_the_reference_clip_and_rejects_a_url(monkeypatch, tmp_path):
+    calls = []
+    sidecar = _load_sidecar(monkeypatch, calls)
+    ref = tmp_path / "ref.wav"
+    ref.write_bytes(b"x")
+    sidecar._handle_synthesize({"text": "hi", "ref_audio": str(ref)}, io.BytesIO())
+    assert dict(calls)["synthesize"]["prompt_audio_path"] == str(ref)
+    with pytest.raises(ValueError, match="local file path"):
+        sidecar._handle_synthesize({"text": "hi", "ref_audio": "https://x.test/a.wav"}, io.BytesIO())
+
+
+def test_resamples_to_the_rate_the_engine_reports(monkeypatch):
+    sidecar = _load_sidecar(monkeypatch, [], sample_rate=24000, channels=1, samples=960)
+    out = io.BytesIO()
+    sidecar._handle_synthesize({"text": "hi"}, out)
+    audio = _frames(out)[-1]
+    assert audio["sample_rate"] == 48000
+    assert audio["n_samples"] == 1920
+
+
+def test_only_the_cold_call_sends_progress(monkeypatch):
+    """Progress frames keep the watchdog armed through downloads; a warm call
+    sending them would stop it from catching a generation that wedges."""
+    sidecar = _load_sidecar(monkeypatch, [])
+    first, second = io.BytesIO(), io.BytesIO()
+    sidecar._handle_synthesize({"text": "one"}, first)
+    sidecar._handle_synthesize({"text": "two"}, second)
+    assert any(f["op"] == "progress" for f in _frames(first))
+    assert [f["op"] for f in _frames(second)] == ["audio"]
+
+
+def test_the_sidecar_imports_nothing_from_the_app():
+    src = _MAIN.read_text(encoding="utf-8")
+    for name in ("services", "core", "engines", "api", "backend", "utils"):
+        assert not re.search(rf"^\s*(from|import) {name}\b", src, re.M), name
+
+
+def test_the_class_switches_to_the_sidecar_once_its_venv_exists(monkeypatch, tmp_path):
+    from engines.moss_tts_nano_subprocess import MossTTSNanoSubprocessBackend
+    from services import tts_backend
+    from services.sidecar_install import _venv_python
+
+    monkeypatch.setenv("OMNIVOICE_MOSS_TTS_NANO_DIR", "")
+    monkeypatch.delenv("OMNIVOICE_MOSS_TTS_NANO_DIR")
+    assert tts_backend.get_backend_class("moss-tts-nano") is tts_backend.MossTTSNanoBackend
+
+    py = _venv_python(tmp_path / ".venv")
+    py.parent.mkdir(parents=True)
+    py.write_text("#!fake\n")
+    monkeypatch.setenv("OMNIVOICE_MOSS_TTS_NANO_DIR", str(tmp_path))
+
+    cls = tts_backend.get_backend_class("moss-tts-nano")
+    assert cls is MossTTSNanoSubprocessBackend
+    assert cls.venv_python() == py
+    assert cls.is_available() == (True, "ready")
+    for attr in ("id", "display_name", "gpu_compat"):
+        assert getattr(cls, attr) == getattr(tts_backend.MossTTSNanoBackend, attr), attr
+    assert cls().supported_languages == tts_backend.MossTTSNanoBackend().supported_languages
+
+
+def test_every_own_venv_engine_has_an_installer_that_sets_its_path():
+    """The resolver switches on the env var the engine's module reads; the
+    installer must be the thing that sets that same variable."""
+    import importlib
+
+    from services import sidecar_install, tts_backend
+
+    for engine_id, (module_name, class_name) in tts_backend._OWN_VENV_SIDECARS.items():
+        module = importlib.import_module(module_name)
+        spec = sidecar_install.get_spec(engine_id)
+        assert spec is not None, engine_id
+        assert spec.env_var == module.VENV_ENV_VAR, engine_id
+        assert getattr(module, class_name).id == engine_id

--- a/tests/test_sidecar_install.py
+++ b/tests/test_sidecar_install.py
@@ -1090,11 +1090,12 @@ def test_verify_probe_runs_in_the_engines_venv_and_compiles(monkeypatch, engine_
 @pytest.mark.parametrize(
     ("family", "platform", "machine", "expected"),
     [
-        ("cuda", "linux", "x86_64", {"moss-tts-v15", "dots-tts", "pockettts", "voxcpm2"}),
-        ("cuda", "win32", "AMD64", {"moss-tts-v15", "pockettts", "voxcpm2"}),
-        ("cpu", "win32", "AMD64", {"pockettts", "voxcpm2"}),
-        ("mps", "darwin", "arm64", {"dots-tts", "pockettts", "voxcpm2"}),
-        # Intel Mac: PyTorch publishes no build PocketTTS or VoxCPM2 can use.
+        ("cuda", "linux", "x86_64", {"moss-tts-v15", "dots-tts", "pockettts", "voxcpm2", "moss-tts-nano"}),
+        ("cuda", "win32", "AMD64", {"moss-tts-v15", "pockettts", "voxcpm2", "moss-tts-nano"}),
+        ("cpu", "win32", "AMD64", {"pockettts", "voxcpm2", "moss-tts-nano"}),
+        ("mps", "darwin", "arm64", {"dots-tts", "pockettts", "voxcpm2", "moss-tts-nano"}),
+        # Intel Mac: PyTorch publishes no build PocketTTS, VoxCPM2 or
+        # MOSS-TTS-Nano can use.
         ("cpu", "darwin", "x86_64", {"dots-tts"}),
     ],
 )
@@ -1224,6 +1225,8 @@ _UPSTREAM_ROOT_FILES = {
     "moss-tts-v15": ("pyproject.toml", "README.md", "LICENSE", "MANIFEST.in"),
     "confucius4-tts": ("requirements.txt", "setup.py", "README.md", "LICENSE", "server.py"),
     "dots-tts": ("pyproject.toml", "README.md", "LICENSE", "constraints/recommended.txt"),
+    "moss-tts-nano": ("pyproject.toml", "moss_tts_nano_runtime.py", "requirements.txt",
+                      "README.md", "LICENSE"),
 }
 
 

--- a/tests/test_sidecar_stdout_isolation_1428.py
+++ b/tests/test_sidecar_stdout_isolation_1428.py
@@ -47,6 +47,7 @@ EXPECTED_SIDECARS = {
     ENGINES / "omnivoice_subprocess" / "main.py",
     ENGINES / "pockettts" / "main.py",
     ENGINES / "voxcpm2_subprocess" / "main.py",
+    ENGINES / "moss_tts_nano_subprocess" / "main.py",
     ENGINES / "supertonic3" / "sidecar.py",
 }
 


### PR DESCRIPTION
Stacked on #2021, which is stacked on #2016. This PR retargets as those merge.

## What changes for users

- **MOSS-TTS-Nano gets an Install button** in Model Catalogue → Engines.
  - It installs a reviewed upstream commit into its own folder and Python environment, and runs it there in a separate process.
  - Nothing it installs touches VoiceStudio or another engine, and **Uninstall** removes only its folder.
- **It works with today's upstream.** The in-process engine looks for a model class that `moss_tts_nano` no longer exports: at the pinned commit the package exports only `__version__`. So after a manual install it reports "no usable model class". The sidecar drives upstream's own runtime, `moss_tts_nano_runtime.NanoTTSService`.
- **The right build for each host:**
  - NVIDIA GPUs get the CUDA build of torch 2.7.0, resolved to `+cu128` on Windows and Linux.
  - Apple Silicon gets the regular build.
  - The engine is not offered on Intel Macs, where torch 2.7.0 has no build.

## How

- **Spec:** `moss-tts-nano` is pinned to `8b7bcc93` (2026-09-06).
  - It uses an editable install and the existing CUDA index args. Upstream pins torch exactly, as Confucius4 does.
  - The probe is `import moss_tts_nano_runtime`.
- **`engines/moss_tts_nano_subprocess/main.py`** is a self-contained sidecar. It:
  - calls `preload(load_model=True)`;
  - heartbeats through the model and audio-tokenizer downloads, and only then;
  - downmixes to mono and resamples to 48 kHz if upstream returns another rate;
  - reuses one output file.
- **The resolver is now a table** (`_OWN_VENV_SIDECARS`) now that two engines use it. The three identical Intel-Mac gates are one factory.

## Tests

`tests/test_moss_tts_nano_subprocess.py` covers:
- the runtime calls, with default checkpoint and tokenizer, preload, voice-clone mode and one reused output file;
- the reference clip, and URL rejection;
- the stereo downmix and the resampling;
- progress frames on the cold call only;
- no app imports;
- the class switch keeping every attribute;
- each own-venv engine's env var matching its installer's.

The installer suite's per-host sets and upstream-layout fixtures include the new spec.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds isolated installation and sidecar execution for MOSS-TTS-Nano using reviewed commit `8b7bcc93` and host-specific environments. This keeps dependencies separate while supporting voice cloning, progress reporting, audio normalization, and safe local-only reference audio. Review the pinned upstream commit, model-download retry behavior, and Intel Mac gating before merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->