### PR TITLE
fix(translation): uninstalling an engine never removes what others need

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ the frozen-backend fallback mirror it for their toolchains.
 ## [Unreleased]
 
 **Highlights**
-- Uninstalling a translation engine no longer removes a package VoiceStudio or another engine still needs (#2019)
 - A pronunciation entry that is stored but not applied yet says so, instead of looking like it did not match (#1949)
 - A bare 500 report now names the backend error class, so two unrelated faults stop filing the same issue (#1773)
 - A rejected dubbing source language now names the code it rejected (#1960)
@@ -96,6 +95,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- Uninstalling a translation engine no longer removes a package VoiceStudio or another engine still needs (#2019)
 - Closing the dictation pill on Windows removes it from the screen: an empty dark rectangle used to stay there, always on top, until the app was quit (#2009)
 - The dictation pill on Windows no longer sits inside a bordered card wider than the pill itself (#2009)
 - Dictation uses the model you picked instead of one remembered from before the backend started, so it stops reporting no speech-to-text model while one is installed — and when none is, the main window offers the download (#2012)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ the frozen-backend fallback mirror it for their toolchains.
 ## [Unreleased]
 
 **Highlights**
+- Uninstalling a translation engine no longer removes a package VoiceStudio or another engine still needs (#2019)
 - A pronunciation entry that is stored but not applied yet says so, instead of looking like it did not match (#1949)
 - A bare 500 report now names the backend error class, so two unrelated faults stop filing the same issue (#1773)
 - A rejected dubbing source language now names the code it rejected (#1960)

--- a/backend/api/routers/engines.py
+++ b/backend/api/routers/engines.py
@@ -204,6 +204,11 @@ async def uninstall_translation_engine(engine_id: str):
     pkg = entry.get("pip_package")
     if not pkg:
         return {"status": "no_op", "engine": engine_id}
+    # The builtin flag is a promise someone has to remember to make; this
+    # check does not depend on it (#2019).
+    blocked = translation_engines.uninstall_blocker(engine_id)
+    if blocked:
+        raise HTTPException(status_code=blocked[0], detail=blocked[1])
     rc, out = await translation_engines.run_pip(["uninstall", "-y", pkg])
     if rc != 0:
         raise HTTPException(status_code=500, detail=f"pip uninstall {pkg} failed ({rc}): {out[-1000:]}")

--- a/backend/services/translation_engines.py
+++ b/backend/services/translation_engines.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import asyncio
 import importlib
 import logging
+import functools
+import re
 import os
 import shutil
 import subprocess
@@ -91,6 +93,8 @@ REGISTRY: dict[str, dict] = {
         "probe_module": "openai",
         "category": "llm",
         "needs_key": True,
+        # A core dependency: Settings → LLM Providers uses it too.
+        "builtin": True,
         "notes": (
             "Uses the LLM provider you configure in Settings → LLM Providers "
             "(route it via the 'Dub translation' skill in Settings → LLM Skills): "
@@ -179,6 +183,65 @@ def list_engines() -> list[dict]:
             entry["configured_via"] = via
         out.append(entry)
     return out
+
+
+def _normalize(name: str) -> str:
+    """A distribution name in PEP 503 form (deep_translator == deep-translator)."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+@functools.lru_cache(maxsize=1)
+def _app_dependency_names() -> frozenset[str]:
+    """Distribution names VoiceStudio itself requires, normalized.
+
+    Read from the installed package metadata, so it follows the lockfile with
+    no second list to keep in step. Without metadata this guards nothing
+    rather than failing.
+    """
+    try:
+        from importlib.metadata import requires
+
+        reqs = requires("omnivoice") or []
+    except Exception:  # noqa: BLE001
+        return frozenset()
+    names = set()
+    for req in reqs:
+        if "extra ==" in req:
+            continue
+        names.add(_normalize(re.split(r"[\s;<>=!~\[@(]", req, maxsplit=1)[0]))
+    return frozenset(names)
+
+
+def uninstall_blocker(engine_id: str) -> "tuple[int, str] | None":
+    """Why removing this engine's package would break something, or None.
+
+    `pip uninstall` acts on the app's own environment. A package VoiceStudio
+    depends on (openai, argostranslate) would break the app, and a package
+    other translation engines share (deep_translator backs four) would break
+    those engines too.
+    """
+    entry = REGISTRY.get(engine_id)
+    pkg = entry.get("pip_package") if entry else None
+    if not pkg:
+        return None
+    if _normalize(pkg) in _app_dependency_names():
+        return 400, (
+            f"{entry['display_name']} uses {pkg}, which VoiceStudio itself "
+            "depends on. Uninstalling it would break the app."
+        )
+    sharing = [
+        other["display_name"]
+        for other_id, other in REGISTRY.items()
+        if other_id != engine_id
+        and other.get("pip_package")
+        and _normalize(other["pip_package"]) == _normalize(pkg)
+    ]
+    if sharing:
+        return 409, (
+            f"{entry['display_name']} shares {pkg} with {', '.join(sharing)}. "
+            "Uninstalling it would stop those working too."
+        )
+    return None
 
 
 def get_engine(engine_id: str) -> dict | None:

--- a/tests/test_translation_uninstall_guard.py
+++ b/tests/test_translation_uninstall_guard.py
@@ -1,0 +1,76 @@
+"""Uninstalling a translation engine must never break the app or another engine (#2019).
+
+`pip uninstall` acts on VoiceStudio's own environment. The LLM engine's package
+(openai) is a core dependency of the app, and deep_translator backs four online
+engines at once, so removing either through one engine broke something else.
+"""
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+
+def _router():
+    # Resolved at call time: other suites purge `services` from sys.modules, so
+    # the module the router holds is the one to patch.
+    from api.routers import engines as engines_router
+
+    return engines_router, engines_router.translation_engines
+
+
+def _uninstall(monkeypatch, engine_id, *, pip=None):
+    engines_router, te = _router()
+    monkeypatch.setattr(te, "is_frozen", lambda: False)
+
+    async def no_pip(args, timeout=600.0):
+        pytest.fail(f"pip ran: {args}")
+
+    monkeypatch.setattr(te, "run_pip", pip or no_pip)
+    return asyncio.run(engines_router.uninstall_translation_engine(engine_id))
+
+
+def test_every_engine_backed_by_an_app_dependency_is_builtin():
+    _, te = _router()
+    core = te._app_dependency_names()
+    assert "openai" in core and "argostranslate" in core  # the metadata is readable here
+    for engine_id, entry in te.REGISTRY.items():
+        pkg = entry.get("pip_package")
+        if pkg and te._normalize(pkg) in core:
+            assert entry.get("builtin"), engine_id
+
+
+def test_a_package_the_app_depends_on_is_never_uninstalled(monkeypatch):
+    # Even through an entry nobody marked builtin.
+    _, te = _router()
+    monkeypatch.setitem(te.REGISTRY, "x-llm", {"id": "x-llm", "display_name": "X", "pip_package": "openai"})
+    with pytest.raises(HTTPException) as err:
+        _uninstall(monkeypatch, "x-llm")
+    assert err.value.status_code == 400
+    assert "VoiceStudio itself" in err.value.detail
+
+
+def test_a_package_other_engines_share_is_never_uninstalled(monkeypatch):
+    with pytest.raises(HTTPException) as err:
+        _uninstall(monkeypatch, "google")
+    assert err.value.status_code == 409
+    for name in ("DeepL", "Microsoft", "MyMemory"):
+        assert name in err.value.detail
+
+
+def test_names_compare_in_normalized_form():
+    _, te = _router()
+    assert te._normalize("deep_translator") == te._normalize("Deep-Translator") == "deep-translator"
+
+
+def test_an_unshared_optional_package_can_still_be_uninstalled(monkeypatch):
+    _, te = _router()
+    monkeypatch.setitem(te.REGISTRY, "solo", {"id": "solo", "display_name": "Solo", "pip_package": "solo-translator"})
+    ran = []
+
+    async def fake_pip(args, timeout=600.0):
+        ran.append(args)
+        return 0, "ok"
+
+    res = _uninstall(monkeypatch, "solo", pip=fake_pip)
+    assert res["status"] == "uninstalled"
+    assert ran == [["uninstall", "-y", "solo-translator"]]


### PR DESCRIPTION
Fixes #2019.

## What was wrong

`DELETE /engines/translation/{id}` runs `pip uninstall -y <package>` on VoiceStudio's own environment. Two cases broke something besides the engine being removed:

- **LLM (OpenAI-compatible).** Its package is `openai`, a core dependency that Settings → LLM Providers also uses. Argos, whose package is also a core dependency, was marked `builtin`; this entry was not, so uninstalling it removed `openai` from the app.
- **Google, DeepL, Microsoft and MyMemory** share `deep_translator`. Uninstalling any one removed it for all four.

The route is API-only today (the UI has no uninstall button for translation engines), so the risk was limited to scripts and API clients.

## Change

- `translation_engines.uninstall_blocker()` runs before any uninstall:
  - It refuses with **400** a package VoiceStudio itself depends on. The list comes from the installed package metadata (`importlib.metadata.requires("omnivoice")`), so it follows the lockfile with no second list to maintain.
  - It refuses with **409** a package another engine shares, and names the engines that would stop working.
  - Names are compared in PEP 503 form, so `deep_translator` matches `deep-translator`.
- The `openai` entry is marked `builtin`.

## Tests

`tests/test_translation_uninstall_guard.py`:

- every registry entry backed by an app dependency is `builtin`;
- an unflagged entry that uses a core package is still refused;
- a shared package is refused, and the other three engines are named;
- names compare in normalized form;
- an unshared optional package can still be uninstalled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Translation engine uninstallation now blocks removal of application dependencies and packages shared with other translation engines. It uses normalized package names and returns clear HTTP errors to prevent breakage. Review dependency metadata lookup and shared-package detection for edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->