### PR TITLE
fix(engines): engine installs never inherit VoiceStudio's own uv config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ the frozen-backend fallback mirror it for their toolchains.
 ## [Unreleased]
 
 **Highlights**
+- One-click engine installs no longer inherit VoiceStudio's own PyTorch pin, which made MOSS-TTS-v1.5 and Confucius4 impossible to install (#NOCFGPR)
 - MOSS-TTS-v1.5, Confucius4-TTS, dots.tts, Supertonic-3 and PocketTTS install in one click, each in its own environment, so switching engines and back never breaks a working one (#2015, #2016)
 - A pronunciation entry that is stored but not applied yet says so, instead of looking like it did not match (#1949)
 - A bare 500 report now names the backend error class, so two unrelated faults stop filing the same issue (#1773)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ the frozen-backend fallback mirror it for their toolchains.
 ## [Unreleased]
 
 **Highlights**
-- One-click engine installs no longer inherit VoiceStudio's own PyTorch pin, which made MOSS-TTS-v1.5 and Confucius4 impossible to install (#NOCFGPR)
+- One-click engine installs no longer inherit VoiceStudio's own PyTorch pin, which made MOSS-TTS-v1.5 and Confucius4 impossible to install (#2024)
 - MOSS-TTS-v1.5, Confucius4-TTS, dots.tts, Supertonic-3 and PocketTTS install in one click, each in its own environment, so switching engines and back never breaks a working one (#2015, #2016)
 - A pronunciation entry that is stored but not applied yet says so, instead of looking like it did not match (#1949)
 - A bare 500 report now names the backend error class, so two unrelated faults stop filing the same issue (#1773)

--- a/backend/services/sidecar_install.py
+++ b/backend/services/sidecar_install.py
@@ -549,13 +549,20 @@ def _default_uv_cache_root() -> Path:
     return Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache") / "uv"
 
 
-def uv_subprocess_env(cache_parent: Path) -> "dict[str, str] | None":
+def uv_subprocess_env(cache_parent: Path) -> "dict[str, str]":
     """Environment for ``uv`` subprocesses that install into *cache_parent*'s volume.
 
-    Returns ``None`` (inherit the parent environment untouched) when uv's
-    default cache already shares a volume with *cache_parent* or the user
-    pinned both variables themselves. Otherwise returns a copy of
-    ``os.environ`` with the *unset* one(s) of ``UV_CACHE_DIR`` /
+    Always a copy of ``os.environ`` with ``UV_NO_CONFIG=1``: an engine's
+    install resolves its own requirements, never VoiceStudio's. The backend
+    runs inside the app's tree, so uv would otherwise discover the app's
+    ``pyproject.toml`` and apply its ``[tool.uv] constraint-dependencies``
+    (``torch==2.8.0``) to the engine's venv. An engine pinning another torch
+    (MOSS-TTS-v1.5, Confucius4) could then never resolve, and one that pins
+    none got the app's torch instead of its own. Mirrors still apply: they
+    arrive as ``UV_INDEX_URL``, an environment variable, not a config file.
+
+    When uv's default cache is on another volume than *cache_parent*, the
+    copy also places the *unset* one(s) of ``UV_CACHE_DIR`` /
     ``UV_PYTHON_INSTALL_DIR`` placed inside *cache_parent*, so downloads, the
     unpacked wheel cache, managed Pythons, and the venv all stay on the
     target volume — and same-volume hardlink installs work again. The two
@@ -568,17 +575,15 @@ def uv_subprocess_env(cache_parent: Path) -> "dict[str, str] | None":
     pass the directory that should hold the shared ``.uv-cache`` — typically
     the common parent of the engine venvs on that volume.
     """
-    if _same_volume(cache_parent, _default_uv_cache_root()):
-        return None
     env = dict(os.environ)
-    overrode = False
+    env["UV_NO_CONFIG"] = "1"
+    if _same_volume(cache_parent, _default_uv_cache_root()):
+        return env
     if not env.get("UV_CACHE_DIR"):  # explicit user choice always wins
         env["UV_CACHE_DIR"] = str(Path(cache_parent) / ".uv-cache")
-        overrode = True
     if not env.get("UV_PYTHON_INSTALL_DIR"):
         env["UV_PYTHON_INSTALL_DIR"] = str(Path(cache_parent) / ".uv-python")
-        overrode = True
-    return env if overrode else None
+    return env
 
 
 # ── Disk preflight ─────────────────────────────────────────────────────────

--- a/tests/test_uv_cross_drive.py
+++ b/tests/test_uv_cross_drive.py
@@ -73,12 +73,13 @@ def test_same_volume_false_across_devices(tmp_path, monkeypatch):
 
 # ── uv_subprocess_env ──────────────────────────────────────────────────────
 
-def test_uv_env_is_none_on_the_default_cache_volume(tmp_path, monkeypatch):
-    """Same volume as uv's default cache → inherit env untouched (default
-    installs stay byte-identical)."""
+def test_uv_env_moves_no_cache_on_the_default_cache_volume(tmp_path, monkeypatch):
+    """Same volume as uv's default cache → the cache stays where uv puts it."""
     monkeypatch.delenv("UV_CACHE_DIR", raising=False)
+    monkeypatch.delenv("UV_PYTHON_INSTALL_DIR", raising=False)
     monkeypatch.setattr(si, "_default_uv_cache_root", lambda: tmp_path / "uv")
-    assert si.uv_subprocess_env(tmp_path / "engines") is None
+    env = si.uv_subprocess_env(tmp_path / "engines")
+    assert "UV_CACHE_DIR" not in env and "UV_PYTHON_INSTALL_DIR" not in env
 
 
 def test_uv_env_colocates_cache_on_a_foreign_volume(tmp_path, monkeypatch):
@@ -111,12 +112,14 @@ def test_uv_env_respects_user_pinned_cache_dir(tmp_path, monkeypatch):
     assert env["UV_PYTHON_INSTALL_DIR"] == str(tmp_path / "engines" / ".uv-python")
 
 
-def test_uv_env_is_none_when_both_vars_pinned(tmp_path, monkeypatch):
-    """Both pinned → nothing left to override → inherit env untouched."""
+def test_uv_env_keeps_both_vars_when_both_pinned(tmp_path, monkeypatch):
+    """Both pinned → the user's values stand."""
     monkeypatch.setenv("UV_CACHE_DIR", str(tmp_path / "my-cache"))
     monkeypatch.setenv("UV_PYTHON_INSTALL_DIR", str(tmp_path / "my-pythons"))
     monkeypatch.setattr(si, "_same_volume", lambda a, b: False)
-    assert si.uv_subprocess_env(tmp_path / "engines") is None
+    env = si.uv_subprocess_env(tmp_path / "engines")
+    assert env["UV_CACHE_DIR"] == str(tmp_path / "my-cache")
+    assert env["UV_PYTHON_INSTALL_DIR"] == str(tmp_path / "my-pythons")
 
 
 def test_uv_env_respects_user_pinned_python_dir(tmp_path, monkeypatch):
@@ -244,3 +247,74 @@ def test_every_bootstrap_uv_call_passes_env(path):
         "subprocess calls in _bootstrap_engines_venv without env= "
         f"(cross-drive uv cache class): {offenders}"
     )
+
+
+# ── Engine installs never inherit the app's uv config ─────────────────────
+#
+# The backend runs inside VoiceStudio's tree, so a uv process it starts
+# discovers the app's pyproject.toml and applies its [tool.uv]
+# constraint-dependencies (torch==2.8.0). Resolved that way,
+# torch==2.9.1+cu128 (MOSS-TTS-v1.5) and torch==2.7.0 (Confucius4) are
+# unsatisfiable. Every engine install and bootstrap gets its environment from
+# uv_subprocess_env; these pin that it always opts out of config discovery.
+
+
+@pytest.mark.parametrize("same_volume", [True, False])
+@pytest.mark.parametrize("pinned", [(), ("UV_CACHE_DIR",), ("UV_CACHE_DIR", "UV_PYTHON_INSTALL_DIR")])
+def test_uv_env_always_ignores_the_apps_uv_config(tmp_path, monkeypatch, same_volume, pinned):
+    for var in ("UV_CACHE_DIR", "UV_PYTHON_INSTALL_DIR"):
+        if var in pinned:
+            monkeypatch.setenv(var, str(tmp_path / var.lower()))
+        else:
+            monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(si, "_same_volume", lambda a, b: same_volume)
+    env = si.uv_subprocess_env(tmp_path / "engines")
+    assert env["UV_NO_CONFIG"] == "1"
+
+
+def test_uv_env_keeps_the_mirror_setting(tmp_path, monkeypatch):
+    """Region and custom mirrors reach uv as UV_INDEX_URL, which config opt-out
+    leaves alone."""
+    monkeypatch.setenv("UV_INDEX_URL", "https://mirror.example/simple")
+    env = si.uv_subprocess_env(tmp_path / "engines")
+    assert env["UV_INDEX_URL"] == "https://mirror.example/simple"
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "engines.indextts.bootstrap",
+        "engines.moss_tts_v15.bootstrap",
+        "engines.confucius4.bootstrap",
+        "engines.dots_tts.bootstrap",
+    ],
+)
+def test_every_engine_bootstrap_ignores_the_apps_uv_config(module):
+    import importlib
+
+    env = importlib.import_module(module)._uv_env()
+    assert env is not None and env["UV_NO_CONFIG"] == "1", module
+
+
+def test_one_click_install_steps_ignore_the_apps_uv_config(tmp_path, monkeypatch):
+    envs = []
+
+    def capture(job, argv, *, timeout, env=None):
+        envs.append((argv[1], env))
+        if argv[1] == "venv":
+            py = si._venv_python(Path(argv[2]))
+            py.parent.mkdir(parents=True, exist_ok=True)
+            py.write_text("#!fake\n")
+        return 0
+
+    monkeypatch.setattr(si, "DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setattr(si, "_locate_uv", lambda: "/fake/uv")
+    monkeypatch.setattr(si, "_run_logged", capture)
+    spec = si.get_spec("indextts2")
+    si.managed_checkout(spec).mkdir(parents=True)
+    job = si._new_job(spec.engine_id)
+    si._step_create_venv(spec, job)
+    si._step_install_deps(spec, job)
+    assert [step for step, _ in envs] == ["venv", "pip"]
+    for step, env in envs:
+        assert env is not None and env["UV_NO_CONFIG"] == "1", step


### PR DESCRIPTION
## What was wrong

The backend runs inside VoiceStudio's own tree, and the `uv` processes it starts for engine installs don't set their own working directory. So uv discovered VoiceStudio's `pyproject.toml` and applied its `[tool.uv] constraint-dependencies` to every engine's venv. Those include `torch==2.8.0`, `torchaudio==2.8.0` and `starlette>=1.3.1`.

Reproduced from the repo root:

```
$ printf 'torch==2.9.1+cu128\n' | uv pip compile - … --extra-index-url …/cu128 --index-strategy unsafe-best-match
  × No solution found when resolving dependencies
$ printf 'torch==2.9.1+cu128\n' | uv pip compile - --no-config …
torch==2.9.1+cu128
```

The same happens from `backend/`, where the desktop backend runs, because uv looks upward for the project.

Consequences:

- **MOSS-TTS-v1.5** (`torch==2.9.1+cu128`) and **Confucius4** (`torch==2.7.0`) could never install, neither by one-click (#2016) nor by their bootstraps.
- **Engines that pin no torch** silently got the app's torch, so their venvs weren't independent.

## Change

`uv_subprocess_env` now always sets `UV_NO_CONFIG=1`. Every one-click install step and all four engine bootstraps (IndexTTS, MOSS-TTS-v1.5, Confucius4, dots.tts) already use it.

- **Always returns an environment.** It used to return `None` in two cases, which meant "inherit"; it now always returns a copy.
- **Mirrors keep working.** Region and custom mirrors reach uv as `UV_INDEX_URL`, an environment variable, so opting out of config files doesn't affect them.
- **Unchanged:** the app's own `uv sync` and the translation installer. Both install into the app's environment and should keep its pins.

## Tests (fail before, pass after)

- `uv_subprocess_env` sets `UV_NO_CONFIG=1` in every combination of volume and pinned cache variables, and keeps `UV_INDEX_URL`.
- Each engine bootstrap's `_uv_env()` carries it.
- The one-click `venv` and `pip install` steps hand it to uv.
- The two tests that asserted the old `None` return now assert the cache behaviour they were really about.

This should land before the v0.5.2 tag, since #2016 ships in it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
`uv_subprocess_env` now returns a copied environment with `UV_NO_CONFIG=1` for engine installations. This prevents VoiceStudio’s `uv` constraints, including its Torch pin, from affecting engine dependency resolution while preserving custom mirrors and cross-volume cache handling. Tests cover engine bootstraps, one-click installation steps, mirror preservation, and cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->