### PR TITLE
fix(release): one job writes the notes and publishes, after every platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -890,8 +890,8 @@ jobs:
 
       # ── Compute SHA-256 checksums (Phase 0 GATE-05) ───────────────────
       # Native OS tools: shasum -a 256 (POSIX) / Get-FileHash (Windows).
-      # Writes SHA256SUMS-<label>.txt for the user-verifiable path AND
-      # captures the content into $GITHUB_OUTPUT for body append.
+      # Writes SHA256SUMS-<label>.txt, attached to the release below. The
+      # release-notes-checksums job puts every leg's file into the notes.
       - name: Compute SHA-256 checksums
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         id: checksums
@@ -944,15 +944,74 @@ jobs:
 
           echo "checksums_file=$OUT" >> "$GITHUB_OUTPUT"
 
-      - name: Append checksums to release + attach SHA256SUMS file
+      # Attach only. The notes are one shared text and the publish is one
+      # decision, so both belong to the single release-notes-checksums job
+      # that runs after the whole matrix (see there for why).
+      - name: Attach SHA256SUMS file
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          append_body: true
-          body_path: ${{ steps.checksums.outputs.checksums_file }}
-          files: ${{ steps.checksums.outputs.checksums_file }}
-          fail_on_unmatched_files: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          FILE: ${{ steps.checksums.outputs.checksums_file }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" "$FILE" --clobber --repo "$GITHUB_REPOSITORY"
+
+  # ── Checksums into the notes, then publish (the single writer) ───────────
+  # Every build leg used to append its checksums to the shared release notes
+  # with softprops/action-gh-release. Two things went wrong:
+  #   - The appends were concurrent read-modify-writes, so a leg that read the
+  #     notes before another wrote them lost its section. v0.5.1 and v0.5.2
+  #     both shipped without the macOS Apple Silicon checksums in the notes.
+  #   - softprops defaults to draft: false, so the FIRST leg to finish
+  #     published tauri-action's draft while the other installers and the
+  #     complete latest.json were still being built (v0.5.2 went public at
+  #     17:27; its latest.json was finished at 17:38).
+  # This job is the only writer of the notes and the only publisher. It runs
+  # once every leg, the manifest repair and the uninstall scripts are done,
+  # writes the four platforms' checksums in a fixed order, and fails if one is
+  # missing, so a failed platform leaves the release a draft.
+  release-notes-checksums:
+    needs: [build, repair-updater-manifest, uninstall-scripts]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      TAG: ${{ github.ref_name }}
+    steps:
+      - name: Write every platform's checksums into the notes, then publish
+        shell: bash
+        run: |
+          set -euo pipefail
+          WORK="$(mktemp -d)"
+          gh release download "$TAG" --repo "$REPO" --pattern 'SHA256SUMS-*.txt' --dir "$WORK"
+          # The checksum sections and the Contributors strip are always the
+          # tail of the notes; drop them so a re-run rebuilds rather than
+          # stacks (contributors-strip re-appends its strip after this job).
+          gh release view "$TAG" --repo "$REPO" --json body --jq .body \
+            | awk '/^### .* artifacts$/ || /^## Contributors$/ {exit} {print}' > "$WORK/notes.md"
+          missing=0
+          for label in "macOS Apple Silicon" "macOS Intel" "Windows x64" "Linux x64"; do
+            file="$WORK/SHA256SUMS-${label// /.}.txt"
+            if [ -f "$file" ]; then
+              cat "$file" >> "$WORK/notes.md"
+            else
+              echo "::error::The release has no checksums for $label"
+              missing=1
+            fi
+          done
+          [ "$missing" = 0 ] || exit 1
+          gh release edit "$TAG" --repo "$REPO" --notes-file "$WORK/notes.md"
+          if [[ "$TAG" == *-* ]]; then
+            gh release edit "$TAG" --repo "$REPO" --draft=false --prerelease
+          else
+            gh release edit "$TAG" --repo "$REPO" --draft=false --latest
+          fi
 
   # ── Uninstall scripts as release assets (#1089) ───────────────────────────
   # The in-app uninstaller (Settings → Storage → Remove all data) is the primary
@@ -1049,11 +1108,12 @@ jobs:
   # MUST append via `gh release edit` on the EXISTING release (never a second
   # softprops publish — that races tauri-action's per-matrix draft and splits
   # installers across two releases; see uninstall-scripts). `needs: [build]`
-  # guarantees the release + all checksum appends already landed, and this job
+  # guarantees the release exists and release-notes-checksums has written the
+  # notes, and this job
   # is single (no matrix) so there is no write race. Idempotent: it strips any
   # prior "## Contributors" block before re-appending, so re-runs don't stack.
   contributors-strip:
-    needs: [build]
+    needs: [build, release-notes-checksums]
     if: >-
       github.event_name == 'push'
       && startsWith(github.ref, 'refs/tags/v')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ the frozen-backend fallback mirror it for their toolchains.
 
 - VoxCPM2 installs in one click into its own environment, with the CUDA build of PyTorch on NVIDIA GPUs (#2021)
 
+### CI
+
+- A tagged release is published only after every platform's installers and checksums are attached, and its notes list all four platforms' checksums (#RELPR)
+
+
 ## [0.5.2] — 2026-09-10
 
 **Highlights**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### CI
 
-- A tagged release is published only after every platform's installers and checksums are attached, and its notes list all four platforms' checksums (#RELPR)
+- A tagged release is published only after every platform's installers and checksums are attached, and its notes list all four platforms' checksums (#2029)
 
 
 ## [0.5.2] — 2026-09-10

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -77,15 +77,20 @@ The `Desktop Release` workflow fires on tag push. It builds four targets in para
 |---|---|---|
 | macOS Apple Silicon | macos-14 | `.dmg` + updater `.app.tar.gz` |
 | macOS Intel | macos-13 | `.dmg` + updater `.app.tar.gz` |
-| Windows x64 | windows-2022 | `.msi` + `.exe` + updater `.nsis.zip` |
-| Linux x64 | ubuntu-22.04 | `.AppImage` + `.deb` + updater `.AppImage.tar.gz` |
+| Windows x64 | windows-2022 | `.msi`, machine-wide and per-user, each with its updater `.sig` |
+| Linux x64 | ubuntu-22.04 | `.AppImage` + updater `.AppImage.sig` |
 
 Each runner signs the updater payload with the stored `TAURI_SIGNING_PRIVATE_KEY`, merges into a single `latest.json`, and attaches everything to the draft release.
 
 Workflow runtime: **~20-40 minutes** (PyInstaller + four platform builds). Follow progress at:
 `https://github.com/debpalash/VoiceStudio/actions`
 
-When it finishes, the draft release needs manual publishing — GitHub → Releases → **Edit** the draft → **Publish release**. Once published, existing clients detect the update on their next launch.
+The release stays a draft while the platforms build. Once every platform, the
+updater-manifest repair and the uninstall scripts are done, the
+`release-notes-checksums` job writes all four platforms' checksums into the
+notes and publishes it, with no manual step. A failed platform leaves the
+release a draft, so nothing half-built goes public. Existing clients detect
+the update on their next launch.
 
 ## 5b. Deployment channels — all must ship (hard rule, owner-set 2026-07-16)
 
@@ -95,7 +100,7 @@ bug to fix immediately, not backlog.
 
 | Channel | Source | Produced by | How to verify |
 |---|---|---|---|
-| GitHub Release: installers + signed `latest.json` (**Stable** updater channel) | the `vX.Y.Z` tag | `release.yml` on tag push | Release page has dmg (arm+intel), msi/exe, AppImage/deb, `latest.json`; body = the CHANGELOG section (not the auto-generated fallback), followed by per-platform checksums and a **Contributors** avatar strip (owner + every PR author for the tag — the `contributors-strip` job) |
+| GitHub Release: installers + signed `latest.json` (**Stable** updater channel) | the `vX.Y.Z` tag | `release.yml` on tag push | Release page has dmg (arm+intel), msi (machine-wide and per-user), AppImage, `latest.json` and `latest-user.json`; body = the CHANGELOG section (not the auto-generated fallback), followed by per-platform checksums and a **Contributors** avatar strip (owner + every PR author for the tag — the `contributors-strip` job) |
 | **Preview** updater channel (rolling `preview` prerelease) | **`main` only** | `release.yml` nightly cron / manual dispatch | preview `latest.json` uses main's version when it is ahead; otherwise it advances the stable patch, then appends `-N` so it semver-sorts above stable |
 | GHCR CUDA image: `:X.Y.Z`, `:X.Y`, `:stable` | the tag | `docker.yml` on tag push | `docker manifest inspect ghcr.io/debpalash/omnivoice-studio:X.Y.Z` |
 | GHCR ROCm image: `:X.Y.Z-rocm`, `:X.Y-rocm`, `:stable-rocm` | the tag | `docker.yml` on tag push | same, with `-rocm` suffix |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -138,7 +138,7 @@ You should see platform-keyed download URLs + minisign signatures. If that JSON 
 
 **Option B — full end-to-end:**
 1. Install v0.1.0 on a fresh machine (or clean-installed Applications).
-2. Cut v0.2.0 (bump, tag, push, wait for CI, publish draft).
+2. Cut v0.2.0 (bump, tag, push, wait for CI; the workflow publishes the release).
 3. Launch the installed v0.1.0. Within seconds, the dialog should appear.
 4. Accept → app downloads, verifies, replaces, relaunches as v0.2.0.
 

--- a/tests/test_release_checksum_notes.py
+++ b/tests/test_release_checksum_notes.py
@@ -1,0 +1,56 @@
+"""Release notes and publishing have one writer, after every platform has built.
+
+Every build leg used to append its checksums to the shared release notes with
+softprops/action-gh-release. The concurrent read-modify-writes lost a section
+(the macOS Apple Silicon one, in both v0.5.1 and v0.5.2), and softprops'
+default draft: false published the draft when the FIRST leg finished, before
+the other installers and the complete latest.json were attached.
+"""
+import re
+from pathlib import Path
+
+WORKFLOW = (Path(__file__).resolve().parents[1] / ".github/workflows/release.yml").read_text(
+    encoding="utf-8"
+)
+
+
+def _job(name: str) -> str:
+    """The text of one top-level job, up to the next job."""
+    start = WORKFLOW.index(f"\n  {name}:\n")
+    nxt = re.search(r"\n  [a-z0-9_-]+:\n", WORKFLOW[start + 1:])
+    return WORKFLOW[start: start + 1 + nxt.start()] if nxt else WORKFLOW[start:]
+
+
+def _code(text: str) -> str:
+    """Without YAML comment lines: an explanation may name what it replaced."""
+    return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
+
+
+def _matrix_labels() -> list[str]:
+    return re.findall(r'^\s+label: "([^"]+)"$', _job("build"), flags=re.M)
+
+
+def test_no_build_leg_writes_the_notes_or_publishes():
+    build = _code(_job("build"))
+    assert "softprops/action-gh-release" not in build
+    assert "append_body" not in build
+    assert "--draft=false" not in build
+
+
+def test_one_job_writes_every_platforms_checksums_in_matrix_order():
+    job = _job("release-notes-checksums")
+    assert "needs: [build, repair-updater-manifest, uninstall-scripts]" in job
+    labels = _matrix_labels()
+    assert labels, "the build matrix no longer declares platform labels"
+    positions = [job.index(f'"{label}"') for label in labels]
+    assert positions == sorted(positions), "sections must follow the matrix order"
+
+
+def test_only_that_job_publishes():
+    job = _code(_job("release-notes-checksums"))
+    assert job.count("--draft=false") >= 1
+    assert _code(WORKFLOW).count("--draft=false") == job.count("--draft=false")
+
+
+def test_the_contributors_strip_edits_the_notes_after_them():
+    assert "needs: [build, release-notes-checksums]" in _job("contributors-strip")

--- a/tests/test_release_checksum_notes.py
+++ b/tests/test_release_checksum_notes.py
@@ -54,3 +54,12 @@ def test_only_that_job_publishes():
 
 def test_the_contributors_strip_edits_the_notes_after_them():
     assert "needs: [build, release-notes-checksums]" in _job("contributors-strip")
+
+
+def test_a_missing_platform_stops_before_the_notes_or_the_publish():
+    """A release missing one platform's checksums must stay a draft: the job
+    exits before it rewrites the notes or publishes anything."""
+    job = _code(_job("release-notes-checksums"))
+    assert "missing=1" in job
+    gate = job.index('[ "$missing" = 0 ] || exit 1')
+    assert gate < job.index("--notes-file") < job.index("--draft=false")


### PR DESCRIPTION
## What went wrong on v0.5.2

Each platform leg in `release.yml` appended its checksums to the release notes with `softprops/action-gh-release` (`append_body: true`). That caused two problems:

- **The release went public before it was complete.** softprops defaults to `draft: false`, so the first leg to finish published tauri-action's draft while the other three were still building. The GitHub API shows v0.5.2 was published at 17:27:27, but its final `latest.json` was written at 17:38:45. Clients checking for updates in that window saw a manifest without every platform.
- **One platform's checksums were missing from the notes.** The appends were concurrent read-modify-writes, so a leg that read the notes before another wrote them lost its section. **v0.5.1 and v0.5.2 both lack the macOS Apple Silicon checksums** in their notes, although `SHA256SUMS-macOS.Apple.Silicon.txt` is attached to both.

The workflow's own comments already warn against concurrent writers: the updater-manifest repair and the contributors strip are single jobs for exactly this reason. The checksum append was the one left behind.

## Change

- **Build legs attach only.** Each leg uploads its `SHA256SUMS-<label>.txt` with `gh release upload --clobber`, which neither edits the notes nor changes draft state.
- **A new `release-notes-checksums` job** runs once, after `build`, `repair-updater-manifest` and `uninstall-scripts`. It:
  - rebuilds the checksum tail of the notes in matrix order, so a re-run doesn't stack sections;
  - fails if any platform's checksums are missing, which leaves the release a draft;
  - then publishes it: `--latest` for a stable tag, `--prerelease` for a `vX.Y.Z-…` tag.
- **`contributors-strip`** now waits for that job, so the notes have one writer at a time.
- **`docs/RELEASING.md`** described a manual publish, and `.exe`, `.deb` and `.nsis.zip` artifacts the workflow no longer builds. It now matches what ships: two MSIs (machine-wide and per-user), the AppImage, `latest.json` and `latest-user.json`, and an automatic publish once everything is attached.

This keeps today's behaviour of publishing automatically, just never early. If you'd rather keep releases as drafts and publish by hand, as the old docs said, the change is one line in the new job.

## Tests (fail before, pass after)

`tests/test_release_checksum_notes.py` pins these guarantees:

- no build leg uses softprops, `append_body` or `--draft=false`;
- the new job covers exactly the matrix's platform labels, in matrix order;
- it's the only publisher;
- the contributors strip runs after it.

Only the first test fails on the current workflow; the other three reference the new job. It first runs for real on the next tag, so the release after v0.5.2 is where to check it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The release workflow now validates all platform checksums, updates release notes, and publishes releases only after all required jobs complete. This prevents incomplete notes and documents the current artifacts and automatic publishing flow. Review the failure path to confirm missing checksums leave the release as a draft before any note changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->