### PR TITLE
test(workers): give Control teardown waits a generous bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ the frozen-backend fallback mirror it for their toolchains.
 ### CI
 
 - A tagged release is published only after every platform's installers and checksums are attached, and its notes list all four platforms' checksums (#2029)
+- A worker-transport test no longer fails when a slow Windows runner takes over 2 seconds to tear down (#2038)
+
 
 
 ## [0.5.2] — 2026-09-10

--- a/tests/test_worker_server_integrity.py
+++ b/tests/test_worker_server_integrity.py
@@ -31,6 +31,12 @@ from worker.scheduler import Scheduler
 from worker.transport import codec, server as server_module
 from worker.transport.server import PROTOCOL_VERSION, REQUIRED_FEATURES, WorkerServicer
 
+# How long a test waits for a Control stream to finish ending. These waits
+# only prove the stream ends; the latency assertions stay at 0.2s. Ending
+# runs the real disconnect path, which persists every queued task, and on a
+# slow Windows runner the 64-task case took longer than the 2s it had.
+_CONTROL_EXIT_TIMEOUT_S = 10.0
+
 ENGINE, MODEL, OP = "indextts", "IndexTTS-2", "tts"
 
 
@@ -1464,7 +1470,7 @@ async def test_blocked_reconnect_persistence_does_not_stall_another_worker(
     assert not control.done()
 
     release[1].set()
-    await asyncio.wait_for(control, timeout=2)
+    await asyncio.wait_for(control, timeout=_CONTROL_EXIT_TIMEOUT_S)
 
 
 @pytest.mark.asyncio
@@ -1847,7 +1853,7 @@ async def test_revocation_wakes_and_ends_an_open_control_stream(plane):
 
     assert plane.servicer.revoke_worker_sessions(plane.worker_id) == 1
     plane.scheduler.on_disconnected(plane.worker_id)
-    await asyncio.wait_for(control, timeout=1)
+    await asyncio.wait_for(control, timeout=_CONTROL_EXIT_TIMEOUT_S)
 
     assert session.stream_open is False
     assert plane.pool.get(plane.worker_id) is None
@@ -1894,7 +1900,7 @@ async def test_revocation_cancels_an_assignment_already_blocked_in_control_write
     assert plane.servicer.revoke_worker_sessions(plane.worker_id) == 1
     plane.scheduler.on_disconnected(plane.worker_id)
     release_write.set()
-    await asyncio.wait_for(control, timeout=1)
+    await asyncio.wait_for(control, timeout=_CONTROL_EXIT_TIMEOUT_S)
 
     assert "assignment" not in written
     assert task.active_attempt is not None


### PR DESCRIPTION
## What happened

On #2020's Smoke (Windows) job, `tests/test_worker_server_integrity.py::test_blocked_reconnect_persistence_does_not_stall_another_worker` failed with a `TimeoutError` (run 34527253130). #2020 doesn't touch worker code.

The failing line was the test's last one, `await asyncio.wait_for(control, timeout=2)`. That wait only covers teardown. After both releases, `Control` ends through the real disconnect path, which persists all 64 queued tasks plus the one bound task. On a slow Windows runner, that took longer than 2 s. `wait_for` then cancelled `Control` mid-persist, which is where the `CancelledError` in the traceback came from.

## Change

- **One named bound:** the three waits that only check that a `Control` stream ends now use `_CONTROL_EXIT_TIMEOUT_S = 10.0`.
  - the one that flaked (was 2 s);
  - the two revocation tests (were 1 s).
- **Assertions unchanged:** another worker's heartbeat and prewarm must still finish within 0.2 s while reconciliation is blocked.
- **Hangs still fail:** a stream that never ends still fails, after 10 s instead of 2 s.

In the last 80 CI runs this test failed only this once. The same file has other tight teardown waits, so the bound is shared rather than bumping one line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Worker tests now use a shared 10-second timeout for `Control` teardown. This prevents flaky failures on slow Windows runners while preserving the 0.2-second heartbeat and prewarm assertions. A non-terminating stream can now delay failure by up to 10 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->