### PR TITLE
fix: stop the running app on Windows before building or wiping

### DIFF
--- a/scripts/desktop-prod-windows-processes.mjs
+++ b/scripts/desktop-prod-windows-processes.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env bun
+// Safely stop Windows processes owned by this checkout's debug build.
+//
+// The Windows counterpart of scripts/desktop_prod_processes.py. `kill_running_instances`
+// in desktop-prod.sh reaches for `pgrep`, `lsof` and POSIX `kill`; Git Bash ships
+// none of them for native Win32 processes, and every lookup is `|| true`-guarded,
+// so the whole step degrades to a silent no-op on Windows. Two consequences, both
+// the exact failures the kill exists to prevent:
+//
+//   1. The stale omnivoice-studio.exe keeps a lock on its own image, so the next
+//      `cargo build` dies with "failed to remove file ... Access is denied.
+//      (os error 5)" after a full compile.
+//   2. On a wipe run the app survives the data deletion, leaving the zombie
+//      backend the script's own header warns about.
+//
+// Ownership is proved by executable path only — strictly under this checkout's
+// target/debug — never by bundle id, so an installed VoiceStudio is left alone
+// (the rule tests/test_desktop_prod_scripts.py::test_kill_is_scoped_to_this_
+// checkouts_build fixes for the Unix path).
+//
+// Termination is identity-bound: `taskkill`/Terminate address a REUSABLE pid, so
+// a pid recycled between listing and kill would take an unrelated process down.
+// stopWindowsProcess() re-checks the creation timestamp inside the same
+// PowerShell pass that terminates, which is why it is reused here rather than
+// reimplemented.
+
+import { spawnSync } from "node:child_process";
+import { stopWindowsProcess } from "./clear-dev-ports.mjs";
+
+/** Process image name of the Tauri debug build (both launch shapes use it). */
+export const APP_EXE = "omnivoice-studio.exe";
+
+/**
+ * Convert an MSYS/Git Bash path to its Win32 form.
+ *
+ * desktop-prod.sh runs under Git Bash, so $TAURI_BUILD_ROOT arrives as
+ * `/c/checkout/...` while Win32_Process reports `C:\checkout\...`. Comparing the
+ * two without this returns no owners and reinstates the silent no-op. Already
+ * Win32-shaped input passes through unchanged, so the helper stays callable from
+ * a native shell too.
+ */
+export function toWindowsPath(value) {
+  const raw = String(value || "");
+  if (!raw) return "";
+  const drive = raw.match(/^\/([A-Za-z])(\/.*)?$/);
+  const win = (drive ? `${drive[1].toUpperCase()}:${drive[2] || "\\"}` : raw).replaceAll("/", "\\");
+  // Trailing separators are stripped so prefix comparison is stable, except on
+  // a bare drive root, where the separator is part of the path (`C:` is the
+  // drive's *current directory*, which is not `C:\`).
+  return /^[A-Za-z]:\\$/.test(win) ? win : win.replace(/\\+$/, "");
+}
+
+/**
+ * True when `executable` sits strictly inside `buildRoot`.
+ *
+ * Prefix matching alone would accept a sibling directory whose name merely
+ * starts with the root (`target\debug-old\`), so the separator is required.
+ * Case-insensitive because Windows paths are.
+ */
+export function ownedByBuild(executable, buildRoot) {
+  const exe = toWindowsPath(executable).toLowerCase();
+  const root = toWindowsPath(buildRoot).toLowerCase();
+  if (!exe || !root) return false;
+  return exe.startsWith(`${root}\\`);
+}
+
+/** Parse the PowerShell payload, which is an object for one match, an array for many. */
+export function parseProcessList(stdout) {
+  const text = String(stdout || "").trim();
+  if (!text) return [];
+  const parsed = JSON.parse(text);
+  return (Array.isArray(parsed) ? parsed : [parsed]).filter(Boolean);
+}
+
+/**
+ * List this checkout's running debug processes as {pid, executable, identity}.
+ *
+ * `Started` is formatted round-trip ('o') so the identity string is byte-stable
+ * and re-comparable by stopWindowsProcess().
+ */
+export function listOwnedProcesses(buildRoot, run = spawnSync) {
+  const script = [
+    `$procs = Get-CimInstance Win32_Process -Filter "Name='${APP_EXE}'"`,
+    "if ($null -ne $procs) {",
+    "  $procs | Select-Object ProcessId,ExecutablePath,@{n='Started';e={$_.CreationDate.ToUniversalTime().ToString('o')}} | ConvertTo-Json -Compress",
+    "}",
+  ].join("; ");
+  const result = run(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    { encoding: "utf8" },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error("Could not enumerate VoiceStudio processes");
+  return parseProcessList(result.stdout)
+    .filter((p) => ownedByBuild(p.ExecutablePath, buildRoot))
+    .map((p) => ({
+      pid: Number(p.ProcessId),
+      executable: p.ExecutablePath,
+      identity: `windows:${p.Started}`,
+    }));
+}
+
+/** True once no owned process remains — i.e. every pid really exited. */
+function stillRunning(buildRoot, run) {
+  return listOwnedProcesses(buildRoot, run).map((p) => p.pid);
+}
+
+/**
+ * Terminate every owned process and wait for it to actually exit.
+ *
+ * Returns the pids that were stopped. Throws when any survives: the caller is
+ * about to delete the app data directory, and a survivor becomes the zombie
+ * backend that answers /health from memory while every route 500s off deleted
+ * files. Refusing is what desktop_prod_processes.py does on Linux for the same
+ * reason, so the two platforms fail the same way.
+ */
+export function stopOwnedProcesses(
+  buildRoot,
+  { run = spawnSync, stop = stopWindowsProcess, waitMs = 5000, sleep = defaultSleep } = {},
+) {
+  const owned = listOwnedProcesses(buildRoot, run);
+  if (owned.length === 0) return [];
+
+  for (const { pid, identity } of owned) stop(pid, false, identity, run);
+
+  const deadline = Date.now() + waitMs;
+  let remaining = stillRunning(buildRoot, run);
+  while (remaining.length > 0 && Date.now() < deadline) {
+    sleep(100);
+    remaining = stillRunning(buildRoot, run);
+  }
+  if (remaining.length > 0) {
+    throw new Error(
+      `VoiceStudio processes did not exit (${remaining.join(", ")}); refusing to reset app data`,
+    );
+  }
+  return owned.map((p) => p.pid);
+}
+
+/** Block without pulling in a timer: the caller is a short-lived CLI. */
+function defaultSleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function main(argv) {
+  const buildRoot = argv[2];
+  if (!buildRoot) {
+    console.error("usage: desktop-prod-windows-processes.mjs <build_root>");
+    return 2;
+  }
+  for (const pid of stopOwnedProcesses(buildRoot)) console.log(pid);
+  return 0;
+}
+
+if (import.meta.main) process.exit(main(process.argv));

--- a/scripts/desktop-prod.sh
+++ b/scripts/desktop-prod.sh
@@ -171,6 +171,29 @@ warn_installed_instance() {
 
 kill_running_instances() {
   local pids=""
+  # Windows has no working path below: Git Bash ships neither pgrep nor lsof,
+  # and MSYS `kill` cannot signal a native Win32 pid. Every lookup is
+  # `|| true`-guarded, so the whole function degraded to a silent no-op — the
+  # stale exe kept a lock on its own image and the next build died with
+  # "failed to remove file ... Access is denied. (os error 5)", while a wipe run
+  # deleted the data out from under a still-live app. The helper is Win32-aware,
+  # scopes ownership to this checkout's build output, binds each kill to the
+  # process instance (pids are reusable), and fails rather than returning while
+  # a process survives — matching desktop_prod_processes.py on Linux.
+  if [ "$PLATFORM" = "windows" ]; then
+    local win_pids
+    if ! win_pids="$(bun "$REPO_ROOT/scripts/desktop-prod-windows-processes.mjs" "$TAURI_BUILD_ROOT")"; then
+      echo "❌ A running VoiceStudio from this checkout could not be stopped."
+      echo "   Close it (or end omnivoice-studio.exe in Task Manager) and retry."
+      exit 1
+    fi
+    if [ -n "$win_pids" ]; then
+      echo "🔪 Terminating running VoiceStudio processes: $(echo "$win_pids" | tr '\n' ' ')"
+      echo "   All stopped."
+      echo ""
+    fi
+    return 0
+  fi
   # One pattern covers both launch shapes: the raw binary and the .app bundle
   # both live under `${TAURI_DIR}/target/debug/`, and `pgrep -f` sees the
   # absolute path, of which that is a substring.

--- a/tests/frontend/desktopProdWindowsProcesses.test.mjs
+++ b/tests/frontend/desktopProdWindowsProcesses.test.mjs
@@ -1,0 +1,142 @@
+// `desktop-prod` must actually stop a running app on Windows.
+//
+// kill_running_instances reaches for pgrep/lsof/POSIX kill, none of which see a
+// native Win32 process from Git Bash, and each lookup is `|| true`-guarded — so
+// the step silently did nothing on Windows. The stale omnivoice-studio.exe then
+// held a lock on its own image and the next `cargo build` failed with
+// "failed to remove file ... Access is denied. (os error 5)" after a full compile.
+//
+// These run on every platform: the PowerShell boundary is injected, so the
+// ownership, pid-identity and survivor rules are checked on Linux CI too.
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  listOwnedProcesses,
+  ownedByBuild,
+  parseProcessList,
+  stopOwnedProcesses,
+  toWindowsPath,
+} from "../../scripts/desktop-prod-windows-processes.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const BUILD_ROOT = "/c/checkout/frontend/src-tauri/target/debug";
+const WIN_BUILD_ROOT = "C:\\checkout\\frontend\\src-tauri\\target\\debug";
+
+/** A PowerShell stub returning `procs` for the list pass. */
+function listStub(batches) {
+  const queue = [...batches];
+  return () => ({
+    status: 0,
+    stdout: (() => {
+      const next = queue.length > 1 ? queue.shift() : queue[0];
+      return next.length === 0 ? "" : JSON.stringify(next.length === 1 ? next[0] : next);
+    })(),
+  });
+}
+
+const proc = (ProcessId, ExecutablePath, Started = "2026-01-01T00:00:00.0000000Z") => ({
+  ProcessId,
+  ExecutablePath,
+  Started,
+});
+
+test("MSYS build roots are converted to their Win32 form", () => {
+  // Git Bash hands the script /c/... while Win32_Process reports C:\... —
+  // comparing the two unconverted matches nothing and restores the no-op.
+  assert.equal(toWindowsPath(BUILD_ROOT), WIN_BUILD_ROOT);
+  assert.equal(toWindowsPath("/d/x"), "D:\\x");
+  assert.equal(toWindowsPath(WIN_BUILD_ROOT), WIN_BUILD_ROOT);
+  assert.equal(toWindowsPath("/c/"), "C:\\");
+  assert.equal(toWindowsPath(""), "");
+});
+
+test("ownership is decided by build path, so an installed copy is spared", () => {
+  assert.equal(ownedByBuild(`${WIN_BUILD_ROOT}\\omnivoice-studio.exe`, BUILD_ROOT), true);
+  // Case-insensitive: Windows paths are.
+  assert.equal(ownedByBuild(`${WIN_BUILD_ROOT.toLowerCase()}\\OMNIVOICE-STUDIO.EXE`, BUILD_ROOT), true);
+  // The installed app is somebody's live session — never ours to kill.
+  assert.equal(
+    ownedByBuild("C:\\Program Files\\VoiceStudio\\omnivoice-studio.exe", BUILD_ROOT),
+    false,
+  );
+  // A sibling whose name merely starts with the root is not inside it.
+  assert.equal(ownedByBuild(`${WIN_BUILD_ROOT}-old\\omnivoice-studio.exe`, BUILD_ROOT), false);
+  // The root itself is a directory, not a process image.
+  assert.equal(ownedByBuild(WIN_BUILD_ROOT, BUILD_ROOT), false);
+  assert.equal(ownedByBuild("", BUILD_ROOT), false);
+});
+
+test("ConvertTo-Json emits an object for one match and an array for many", () => {
+  assert.equal(parseProcessList("").length, 0);
+  assert.equal(parseProcessList(JSON.stringify(proc(1, "x"))).length, 1);
+  assert.equal(parseProcessList(JSON.stringify([proc(1, "x"), proc(2, "y")])).length, 2);
+});
+
+test("only this checkout's processes are listed, with a round-trip identity", () => {
+  const run = listStub([
+    [
+      proc(100, `${WIN_BUILD_ROOT}\\omnivoice-studio.exe`, "2026-01-01T00:00:00.0000000Z"),
+      proc(200, "C:\\Program Files\\VoiceStudio\\omnivoice-studio.exe"),
+    ],
+  ]);
+  const owned = listOwnedProcesses(BUILD_ROOT, run);
+  assert.deepEqual(
+    owned.map((p) => p.pid),
+    [100],
+  );
+  assert.equal(owned[0].identity, "windows:2026-01-01T00:00:00.0000000Z");
+});
+
+test("each kill is bound to the process instance, not the reusable pid", () => {
+  const stopped = [];
+  const run = listStub([[proc(100, `${WIN_BUILD_ROOT}\\omnivoice-studio.exe`)], []]);
+  const pids = stopOwnedProcesses(BUILD_ROOT, {
+    run,
+    stop: (pid, _force, identity) => stopped.push([pid, identity]),
+    sleep: () => {},
+  });
+  assert.deepEqual(pids, [100]);
+  assert.deepEqual(stopped, [[100, "windows:2026-01-01T00:00:00.0000000Z"]]);
+});
+
+test("a survivor fails loudly instead of letting the wipe proceed", () => {
+  // The caller deletes the app data dir next. A survivor becomes the zombie
+  // backend that answers /health from memory while every route 500s off
+  // deleted files — which is why Linux refuses here too.
+  const alive = [proc(100, `${WIN_BUILD_ROOT}\\omnivoice-studio.exe`)];
+  assert.throws(
+    () =>
+      stopOwnedProcesses(BUILD_ROOT, {
+        run: listStub([alive]),
+        stop: () => {},
+        waitMs: 10,
+        sleep: () => {},
+      }),
+    /did not exit.*refusing to reset app data/s,
+  );
+});
+
+test("nothing running is not an error", () => {
+  assert.deepEqual(stopOwnedProcesses(BUILD_ROOT, { run: listStub([[]]), sleep: () => {} }), []);
+});
+
+test("desktop-prod.sh routes Windows to the helper before the POSIX lookups", () => {
+  // Mechanical on purpose: the reason pgrep cannot be used here is not visible
+  // from the pgrep line itself, so the wiring belongs in a test.
+  const sh = readFileSync(resolve(ROOT, "scripts", "desktop-prod.sh"), "utf8");
+  const start = sh.indexOf("kill_running_instances() {");
+  assert.ok(start !== -1, "kill_running_instances is gone");
+  const body = sh.slice(start, sh.indexOf("\n}", start));
+  assert.match(body, /desktop-prod-windows-processes\.mjs/);
+  const branch = body.indexOf('if [ "$PLATFORM" = "windows" ]');
+  const pgrep = body.indexOf("pgrep -f");
+  assert.ok(branch !== -1, "no Windows branch in kill_running_instances");
+  assert.ok(
+    branch < pgrep,
+    "the Windows branch must precede the pgrep path it cannot use",
+  );
+});


### PR DESCRIPTION
## Summary

`kill_running_instances()` in `scripts/desktop-prod.sh` is a silent no-op on Windows. It reaches for `pgrep`, `lsof` and POSIX `kill`; Git Bash ships none of them for native Win32 processes, and every lookup is `|| true`-guarded, so the step reports nothing and does nothing.

Both failures the kill exists to prevent then happen:

1. **The build fails after a full compile.** The stale `omnivoice-studio.exe` keeps a lock on its own image, so `cargo` dies with `failed to remove file ...\target\debug\omnivoice-studio.exe` / `Access is denied. (os error 5)` — with nothing pointing at the still-running app as the cause.
2. **A wipe run deletes data out from under a live app**, producing exactly the zombie backend the script header warns about: `/health` keeps answering from memory while every route 500s off deleted files.

Closing the window is not enough — the process outlives it.

## Changes

- **`scripts/desktop-prod-windows-processes.mjs`** (new) — the Win32 counterpart of `desktop_prod_processes.py`, keeping its contract:
  - Ownership is proved by **executable path**, strictly under this checkout's `target/debug` — never by bundle id, so an installed VoiceStudio is left alone (the rule `test_kill_is_scoped_to_this_checkouts_build` fixes for the Unix path). A separator is required, so a `target\debug-old\` sibling is not mistaken for the root.
  - Termination is **bound to the process instance**. `taskkill`/`Terminate` address a reusable pid, so a pid recycled between listing and kill would take an unrelated process down. `stopWindowsProcess()` from `clear-dev-ports.mjs` re-checks the creation timestamp inside the same PowerShell pass that terminates, so it is reused rather than reimplemented.
  - **A survivor raises** instead of returning, so the caller cannot wipe app data while a process is alive. Linux already refuses for this reason; both platforms now fail the same way.
  - MSYS paths are converted before comparison — the script hands the helper `/c/...` while `Win32_Process` reports `C:\...`, and comparing the two unconverted matches nothing, reinstating the no-op.
- **`scripts/desktop-prod.sh`** — a Windows branch ahead of the POSIX lookups it cannot use, with the reasoning recorded in a comment.
- **`tests/frontend/desktopProdWindowsProcesses.test.mjs`** (new) — 8 cases.

## Type

- [x] 🐛 Bug fix

## Testing

- **8 new `node --test` cases.** The PowerShell boundary is injected, so ownership, pid-identity and survivor rules are exercised **on Linux CI too**, not only on Windows. One case is mechanical, asserting the shell routes Windows before the `pgrep` path, since that reasoning is not visible from the `pgrep` line itself.
- `bun run test:frontend` — **108 passed**.
- `pytest tests/test_desktop_prod_scripts.py` — no new failures; the pre-existing failures on a Windows host are Linux-only cases (`/proc`, `pidfd`), identical before and after this change.
- **Verified live on Windows 11 / Git Bash.** With the app running, `bun run desktop-prod:upgrade` previously failed with `os error 5` after a full compile. It now prints `🔪 Terminating running VoiceStudio processes: 52928 / All stopped.` and completes the build and launch.

Writing the tests first caught a real bug: `/c/` converted to `C:` rather than `C:\`, and on Windows `C:` means the drive's *current directory*, not its root.

## Checklist

- [x] I've tested this locally
- [ ] I've updated relevant documentation (if applicable) — no user-facing behaviour change; the fix restores documented behaviour on Windows
- [x] No local machine paths, logs, or personal env details in this PR
- [ ] Version files are in sync (if version bump) — no version bump
- [x] If this PR changes runtime behavior, the regression fixture still loads green — this touches only dev tooling, not app runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyjkseGz56i292mo27RVsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Windows cleanup now uses a Win32-aware helper to stop only checkout-owned debug processes and fail if any process survives. This fixes Git Bash cleanup so builds and wipes do not continue with stale processes. Review the executable-path ownership and creation-time identity checks because incorrect matching could terminate an unrelated process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->